### PR TITLE
Show complete exception with stack trace and inner exception on Error

### DIFF
--- a/src/ServiceFabric.Extensions.Services.Queryable/Middleware/ODataQueryableMiddleware.cs
+++ b/src/ServiceFabric.Extensions.Services.Queryable/Middleware/ODataQueryableMiddleware.cs
@@ -237,7 +237,7 @@ namespace ServiceFabric.Extensions.Services.Queryable
 			if (e is AggregateException)
 				return InternalServerError(httpContext, (e.InnerException ?? e).Message);
 
-			return InternalServerError(httpContext, e.Message);
+			return InternalServerError(httpContext, e.ToString());
 		}
 
 		private Task HandleCORS(HttpContext httpContext)


### PR DESCRIPTION
Without this change, I get :

```
The type initializer for 'System.Web.Http.OData.Formatter.EdmLibHelpers' threw an exception.
```

With this, I get:
```
"System.TypeInitializationException: The type initializer for 'System.Web.Http.OData.Formatter.EdmLibHelpers' threw an exception. ---> System.IO.FileNotFoundException: Could not load file or assembly 'System.Data.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089'. The system cannot find the file specified.\r\n
   at System.Web.Http.OData.Formatter.EdmLibHelpers..cctor()\r\n
   --- End of inner exception stack trace ---\r\n
   at System.Web.Http.OData.Formatter.EdmLibHelpers.MangleClrTypeName(Type type)\r\n
   at System.Web.Http.OData.Builder.StructuralTypeConfiguration..ctor(ODataModelBuilder modelBuilder, Type clrType)\r\n
   at System.Web.Http.OData.Builder.ODataModelBuilder.AddEntity(Type type)\r\n
   at System.Web.Http.OData.Builder.ODataConventionModelBuilder.AddEntity(Type type)\r\n
   at ServiceFabric.Extensions.Services.Queryable.ReliableStateExtensions.GetMetadataAsync(IReliableStateManager stateManager)\r\n
   at ServiceFabric.Extensions.Services.Queryable.ODataQueryableMiddleware.GetMetadataAsync(HttpContext httpContext, StatefulServiceContext serviceContext, IReliableStateManager stateManager)\r\n
   at ServiceFabric.Extensions.Services.Queryable.ODataQueryableMiddleware.InvokeQueryHandler(HttpContext httpContext, StatefulServiceContext serviceContext, IReliableStateManager stateManager)"

```

Hence, debuggability is easy.